### PR TITLE
Ensure Codex CLI post uses semantic markdown

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -359,25 +359,185 @@ img {
 .post__content {
   color: var(--text);
   font-size: 1.05rem;
+  line-height: 1.8;
+}
+
+.post__content > *:first-child {
+  margin-top: 0;
+}
+
+.post__content > *:last-child {
+  margin-bottom: 0;
+}
+
+.post__content h1,
+.post__content h2,
+.post__content h3,
+.post__content h4 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-top: 3rem;
+  margin-bottom: 1.2rem;
+}
+
+.post__content h1 {
+  font-size: clamp(2rem, 4vw, 2.6rem);
 }
 
 .post__content h2 {
-  margin-top: 2.5rem;
-  margin-bottom: 1rem;
-  font-size: 1.6rem;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+}
+
+.post__content h3 {
+  font-size: clamp(1.3rem, 2.2vw, 1.6rem);
+}
+
+.post__content h4 {
+  font-size: 1.2rem;
 }
 
 .post__content p {
-  margin-bottom: 1.4rem;
+  margin: 0 0 1.6rem;
+}
+
+.post__content strong {
+  font-weight: 600;
+}
+
+.post__content em {
+  font-style: italic;
+}
+
+.post__content a {
+  position: relative;
+  color: var(--primary);
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 0.25em;
+  transition: color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: inset 0 -0.25em rgba(58, 93, 255, 0.18);
+}
+
+.post__content a:hover,
+.post__content a:focus {
+  color: var(--primary-dark);
+  box-shadow: inset 0 -0.9em rgba(58, 93, 255, 0.28);
+}
+
+.post__content a:focus-visible {
+  outline: 2px solid rgba(43, 72, 198, 0.5);
+  outline-offset: 3px;
+}
+
+.post__content ul,
+.post__content ol {
+  margin: 0 0 1.8rem;
+  padding-left: 1.6rem;
 }
 
 .post__content ul {
-  margin-bottom: 1.6rem;
-  padding-left: 1.5rem;
+  list-style: disc;
+}
+
+.post__content ol {
+  list-style: decimal;
 }
 
 .post__content li + li {
-  margin-top: 0.5rem;
+  margin-top: 0.4rem;
+}
+
+.post__content blockquote {
+  margin: 0 0 2rem;
+  padding: 1.6rem 2rem;
+  background: rgba(58, 93, 255, 0.08);
+  border-left: 4px solid var(--primary);
+  border-radius: calc(var(--radius) / 2);
+  color: var(--text);
+  font-style: italic;
+}
+
+.post__content code {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.95rem;
+  background: rgba(29, 31, 47, 0.08);
+  padding: 0.2em 0.4em;
+  border-radius: 6px;
+}
+
+.post__content pre {
+  margin: 0 0 2.2rem;
+  padding: 1.6rem;
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.post__content pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.post__content hr {
+  border: none;
+  border-top: 1px solid rgba(29, 31, 47, 0.12);
+  margin: 3rem 0;
+}
+
+.post__content img,
+.post__content figure {
+  margin: 2.5rem 0;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.post__content figure figcaption {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  margin-top: 0.6rem;
+  text-align: center;
+}
+
+.post__content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 2.2rem;
+  font-size: 0.98rem;
+}
+
+.post__content th,
+.post__content td {
+  border: 1px solid rgba(29, 31, 47, 0.15);
+  padding: 0.75rem 1rem;
+  text-align: left;
+}
+
+.post__content thead th {
+  background: rgba(58, 93, 255, 0.08);
+}
+
+.post__content tbody tr:nth-child(even) {
+  background: rgba(29, 31, 47, 0.03);
+}
+
+.post__content mark {
+  background: #fde68a;
+  padding: 0.1em 0.25em;
+  border-radius: 4px;
+}
+
+.post__content kbd {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.85rem;
+  background: rgba(29, 31, 47, 0.1);
+  border-radius: 6px;
+  padding: 0.2em 0.5em;
+  box-shadow: inset 0 -1px 0 rgba(29, 31, 47, 0.2);
 }
 
 .post__aside {

--- a/assets/js/post.js
+++ b/assets/js/post.js
@@ -42,6 +42,15 @@ if (!post) {
     .then((markdown) => {
       if (!postContent) return;
       postContent.innerHTML = marked.parse(markdown);
+
+      const firstElement = postContent.firstElementChild;
+      if (
+        firstElement &&
+        firstElement.tagName === 'H1' &&
+        firstElement.textContent.trim().toLowerCase() === post.title.trim().toLowerCase()
+      ) {
+        firstElement.remove();
+      }
     })
     .catch(() => {
       renderNotFound();

--- a/post.html
+++ b/post.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@600;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="assets/css/style.css" />

--- a/posts/gpt_5_codex_cli.md
+++ b/posts/gpt_5_codex_cli.md
@@ -1,60 +1,59 @@
-Building a Name CLI with GPT-5-Codex
+# Building a Name CLI with GPT-5-Codex
 
-*Project repo:* github.com/curtiscovington/ssa-names
+*Project repo: [github.com/curtiscovington/ssa-names](https://github.com/curtiscovington/ssa-names)*
 
 I handed GPT-5-Codex the SSA's baby-name dataset and asked it to build a CLI. No plan, just curiosity about what modern AI could deliver when paired with a real dataset. Two hours later, I had a tool that could generate statistically accurate random names—and I'd validated it with proper hypothesis testing. Yay statistics!
 
-The Hook: Probabilistic Name Generation
+## The Hook: Probabilistic Name Generation
 
 The most interesting feature turned out to be the random name generator. It samples from the actual distribution of baby names in the SSA dataset, meaning if you ask for a random female name from California in 2019, you're far more likely to get "Olivia" (2,610 occurrences) than "Zelda" (maybe 5).
 
 This required solving a classic computer science problem: weighted random sampling. Given a list of items with different frequencies, pick one at random such that the probability matches the real-world distribution.
 
-Why This Matters
+## Why This Matters
 
 Most sampling code you'll find online uses the naive approach: build a cumulative sum array, pick a random number, binary search. That's O(log n) per sample. For a baby-name generator that might run thousands of times, we can do better.
 
 The solution is the alias method—a 1970s algorithm that does O(n) preprocessing to enable O(1) sampling forever after. Here's how it works:
 
-Scale all probabilities so their average equals 1
-
-Partition into "small" (< 1) and "large" (≥ 1) buckets
-
-Pair each small probability with a large one as an "alias"
-
-To sample: pick a random index, then either keep it or jump to its alias based on a coin flip
+1. Scale all probabilities so their average equals 1.
+2. Partition into "small" (< 1) and "large" (≥ 1) buckets.
+3. Pair each small probability with a large one as an "alias".
+4. To sample: pick a random index, then either keep it or jump to its alias based on a coin flip.
 
 The implementation is elegant. Codex drafted it, I refined the edge cases, and then—critically—I validated it.
 
-Statistical Rigor: Actually Testing the Distribution
+## Statistical Rigor: Actually Testing the Distribution
 
 Most AI coding articles end with "it works!" This one ends with proof.
 
 I wrote tests that validate the sampler using two techniques from probability theory:
 
-Single-Name Validation: Binomial Confidence Intervals
+### Single-Name Validation: Binomial Confidence Intervals
 
 If Olivia represents 1.4% of names and we draw 5,000 samples, we expect roughly 70 Olivias. But random variation means we might get 65 or 75. How much variation is acceptable?
 
 The binomial distribution gives us exact bounds. At 99% confidence, 5,000 draws of a 1.4% probability should yield between 51 and 91 successes. My tests compute these intervals using the cumulative distribution function and assert that observed counts fall within bounds across multiple random seeds.
 
+```go
 trials := 5000
 share := 0.014  // Olivia's true proportion
 lower, upper := binomialConfidenceBounds(trials, share, 0.99)
 // Run sampler with different seeds
-// Assert: lower <= observed <= upper
-
+// Assert: lower <= observed && observed <= upper
+```
 
 This catches subtle bugs. If the sampler had even a small bias, the tests would fail across different seeds.
 
-Whole-Distribution Validation: Chi-Square Testing
+### Whole-Distribution Validation: Chi-Square Testing
 
 Testing one name proves that name works. Testing the entire distribution requires the chi-square goodness-of-fit test.
 
-The idea: for each name, compute expected vs. observed counts. If the sampler is unbiased, the sum of (observed - expected)² / expected follows a chi-square distribution. Compare this to the 99th percentile threshold—if you exceed it, your sampler is broken.
+The idea: for each name, compute expected vs. observed counts. If the sampler is unbiased, the sum of `(observed - expected)^2 / expected` follows a chi-square distribution. Compare this to the 99th percentile threshold—if you exceed it, your sampler is broken.
 
 One wrinkle: chi-square requires each category to have at least ~5 expected occurrences. For rare names, I combine them into buckets until this threshold is met.
 
+```go
 chiSquare := 0.0
 for _, bucket := range buckets {
     diff := bucket.observed - bucket.expected
@@ -62,23 +61,22 @@ for _, bucket := range buckets {
 }
 threshold := chiSquaredQuantile(0.99, degreesOfFreedom)
 // Assert: chiSquare < threshold
-
+```
 
 I run this on 20,000 samples. It passes. The alias method produces a distribution statistically indistinguishable from the true dataset.
 
-The Real Dataset Validation
+## The Real Dataset Validation
 
 The final test uses actual SSA data—California 2019 female names, 184,494 births across thousands of names. I validate two ground truth values:
 
-Total births: 184,494
-
-Olivia's count: 2,610
+- Total births: 184,494
+- Olivia's count: 2,610
 
 Then I run the sampler for 6,000 trials across multiple seeds and verify Olivia's draw count falls within the 99% binomial confidence interval. It does.
 
 This proves the sampler works not just on toy data but on real-world distributions with long tails and rare names.
 
-Working With Codex
+## Working With Codex
 
 The collaboration felt like pair programming with a junior engineer who types fast but needs direction. I'd say "implement the alias method" and Codex would draft it. I'd catch edge cases—what if all weights are zero? What about negative counts?—and Codex would patch them.
 
@@ -86,29 +84,31 @@ The tight feedback loop mattered. Go's compiled nature meant every iteration eit
 
 Key insight: AI isn't replacing the thinking; it's handling the translation from idea to code. I still needed to know what the alias method was, why it mattered, and how to validate it properly. Codex just made the implementation phase dramatically faster.
 
-Beyond Random Names: The Full CLI
+## Beyond Random Names: The Full CLI
 
 The tool also answers practical questions:
 
-What are the top names for a place and time?
+### What are the top names for a place and time?
 
+```bash
 $ ssa-names top --state CA --year 2019 --gender F --limit 5
 1. Olivia (2,610)
 2. Emma (2,377)
 3. Mia (2,144)
 ...
+```
 
+### How has a name's popularity changed over decades?
 
-How has a name's popularity changed over decades?
-
+```bash
 $ ssa-names trend --state CA --name Olivia --gender F
-
+```
 
 This generates SVG charts with clean legends and mid-year tick marks. Codex handled the visualization logic; I focused on making the output publication-ready.
 
 One design choice worth noting: the dataset is embedded in the binary. No setup, no downloading files, no version drift. You install the CLI and it just works. This matters for reproducibility—anyone can verify my statistical tests by running the exact same binary.
 
-Lessons Learned
+## Lessons Learned
 
 Validation takes longer than implementation. Writing the sampler took 20 minutes. Writing tests that prove it's correct took an hour. The tests are more valuable than the code.
 
@@ -116,7 +116,7 @@ AI accelerates the boring parts. Parsing CSVs, aggregating data, generating SVG�
 
 Reproducibility matters. Embedding the dataset, adding GitHub Actions for releases, and making the CLI zero-setup turns a toy project into something others can actually use and verify.
 
-What's Next
+## What's Next
 
 The dataset pairs well with other public data. U.S. Census demographics, immigration records, regional birth statistics—these could reveal how naming trends correlate with cultural shifts. The SSA data is clean and accessible, but it's just one dimension of a much richer story.
 
@@ -124,4 +124,4 @@ For the CLI itself, code signing would eliminate the "unidentified developer" wa
 
 This project taught me that AI-assisted development isn't about writing less code—it's about spending time on the parts that matter. Instead of wrestling with CSV parsing, I validated a probabilistic system with proper statistical tests. That's a better use of time, and it's a hint of how development might feel in the future: less typing, more thinking.
 
-If you want to try it yourself, grab the dataset, pick an algorithm that interests you, and let the "ask, build, test" loop surprise you. The code is at github.com/curtiscovington/ssa-names.
+If you want to try it yourself, grab the dataset, pick an algorithm that interests you, and let the "ask, build, test" loop surprise you. The code is at [github.com/curtiscovington/ssa-names](https://github.com/curtiscovington/ssa-names).


### PR DESCRIPTION
## Summary
- rewrite the Codex CLI article with semantic headings, lists, and fenced code blocks so the markdown renderer outputs the correct structure
- linkify the project repository reference and format command examples for consistent presentation

## Testing
- None (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc376e322c8326ab8b6c0be51d0f14