### PR TITLE
Fix duplicate heading in name CLI post

### DIFF
--- a/_posts/2025-09-29-building-a-name-cli-with-gpt-5-codex.md
+++ b/_posts/2025-09-29-building-a-name-cli-with-gpt-5-codex.md
@@ -8,8 +8,6 @@ tags:
   - cli
 reading_time: "6 min read"
 ---
-# Building a Name CLI with GPT-5-Codex
-
 *Project repo: [github.com/curtiscovington/ssa-names](https://github.com/curtiscovington/ssa-names)*
 
 I handed GPT-5-Codex the SSA's baby-name dataset and asked it to build a CLI. No plan, just curiosity about what modern AI could deliver when paired with a real dataset. Two hours later, I had a tool that could generate statistically accurate random names—and I'd validated it with proper hypothesis testing. Yay statistics!


### PR DESCRIPTION
## Summary
- remove the redundant H1 heading from the "Building a Name CLI with GPT-5-Codex" post so the title only renders once

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4b25b450832696c15e3474c3a987