### PR TITLE
Add styled repository card to SSA Names article

### DIFF
--- a/_posts/2025-09-29-building-a-name-cli-with-gpt-5-codex.md
+++ b/_posts/2025-09-29-building-a-name-cli-with-gpt-5-codex.md
@@ -8,7 +8,19 @@ tags:
   - cli
 reading_time: "6 min read"
 ---
-*Project repo: [github.com/curtiscovington/ssa-names](https://github.com/curtiscovington/ssa-names)*
+<a class="repo-card" href="https://github.com/curtiscovington/ssa-names" target="_blank" rel="noopener">
+  <span class="repo-card__icon" aria-hidden="true">
+    <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.73-4.04-1.61-4.04-1.61-.55-1.4-1.33-1.78-1.33-1.78-1.09-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.07 1.84 2.82 1.31 3.51 1 .11-.78.42-1.31.76-1.61-2.66-.3-5.46-1.33-5.46-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.16 0 0 1.01-.32 3.3 1.23a11.53 11.53 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.66 1.64.24 2.86.12 3.16.77.84 1.24 1.91 1.24 3.22 0 4.61-2.8 5.62-5.47 5.92.43.37.81 1.1.81 2.23 0 1.61-.02 2.9-.02 3.29 0 .32.21.7.82.58A12 12 0 0 0 24 12C24 5.37 18.63 0 12 0Z"/>
+    </svg>
+  </span>
+  <span class="repo-card__body">
+    <span class="repo-card__eyebrow">Project repository</span>
+    <span class="repo-card__title">SSA Names CLI</span>
+    <span class="repo-card__description">Explore the weighted sampler, statistical tests, and release automation on GitHub.</span>
+  </span>
+  <span class="repo-card__arrow" aria-hidden="true">↗</span>
+</a>
 
 I handed GPT-5-Codex the SSA's baby-name dataset and asked it to build a CLI. No plan, just curiosity about what modern AI could deliver when paired with a real dataset. Two hours later, I had a tool that could generate statistically accurate random names—and I'd validated it with proper hypothesis testing. Yay statistics!
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -427,6 +427,76 @@ img {
   margin: 0 0 1.6rem;
 }
 
+.post__content .repo-card {
+  display: flex;
+  align-items: center;
+  gap: 1.4rem;
+  margin: 2.5rem 0;
+  padding: 1.4rem 1.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-accent);
+  box-shadow: 0 18px 40px rgba(20, 24, 56, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  color: inherit;
+}
+
+.post__content .repo-card:hover,
+.post__content .repo-card:focus {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 50px rgba(20, 24, 56, 0.12);
+  border-color: rgba(58, 93, 255, 0.35);
+}
+
+.post__content .repo-card:focus-visible {
+  outline: 3px solid rgba(58, 93, 255, 0.5);
+  outline-offset: 4px;
+}
+
+.post__content .repo-card__icon {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(58, 93, 255, 0.16), rgba(122, 140, 255, 0.06));
+  color: var(--primary);
+}
+
+.post__content .repo-card__icon svg {
+  width: 28px;
+  height: 28px;
+  fill: currentColor;
+}
+
+.post__content .repo-card__body {
+  flex: 1;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.post__content .repo-card__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.post__content .repo-card__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.post__content .repo-card__description {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.post__content .repo-card__arrow {
+  font-size: 1.4rem;
+}
+
 .post__content strong {
   font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- replace the plain repository sentence in the SSA Names post with a prominent repo card
- add styles for the repo callout including hover and focus interactions to match the site aesthetic

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68dc6cf324d08326aee668064e728a8e